### PR TITLE
Fix what gets published to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,28 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+build-storybook.log
+/src
+.github
+.storybook
+.env

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/jnwelzel/wf-design-system.git",
   "author": "Jon Welzel <jnwelzel@gmail.com>",
   "license": "MIT",
-  "peerDependencies": {
+  "dependencies": {
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },


### PR DESCRIPTION
We need to have the `dist` folder there man =/
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.0-canary.4.55960f7.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install wf-design-system@1.0.0-canary.4.55960f7.0
  # or 
  yarn add wf-design-system@1.0.0-canary.4.55960f7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
